### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#compiled python
+*.pyc


### PR DESCRIPTION
.gitignore is used to tell git which file types to ignore.  It almost always includes .pyc files so I have added that.
